### PR TITLE
Add free browser-based Cisco DNA Center simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ See full list of Code Samples on [Cisco DevNet CodeExchange](https://developer.c
 ## Resources
 
 
+- [Cisco DNA Center Simulator](https://dnac.networkershome.com)
+  - Free browser-based Cisco DNA Center simulator covering SD-Access fabric, device onboarding, assurance, and automation. No install, no license, no hardware required. Built by [Networkers Home](https://www.networkershome.com) for student practice.
 - [Cisco DNA Center](https://www.cisco.com/c/en/us/products/cloud-systems-management/dna-center/index.html)
   - [Developer Docs](https://developer.cisco.com/docs/dna-center/)
 - [Cisco DevNet](https://developer.cisco.com/)


### PR DESCRIPTION
Hi @robertcsapo! Thanks for maintaining this list. Adding a free, browser-based Cisco DNA Center simulator I built for students preparing for ENSLD / ENSDWI who do not have access to hardware or sandbox slots. It covers SD-Access fabric design, device onboarding, assurance, and automation workflows in a DNAC-style UI. Complements the existing DevNet Learning Labs / Sandbox entries: completely free, no account, aimed at learners. Demo: https://dnac.networkershome.com — happy to adjust format/section if you prefer.